### PR TITLE
Fix for #3

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "xolvio:http-interceptor",
   summary: "Intercepts HTTP calls and allows fake implementations to take over domains. Used for testing.",
-  version: "0.4.0",
+  version: "0.4.1",
   debugOnly: true
 });
 

--- a/server.js
+++ b/server.js
@@ -144,7 +144,7 @@ function _init () {
       timestamp: new Date().getTime(),
       direction: 'OUT',
       request: {
-        options: options,
+        options: JSON.stringify(options),
         method: method.toUpperCase(),
         url: URL.parse(url)
       },


### PR DESCRIPTION
Addresses https://github.com/xolvio/meteor-http-interceptor/issues/3. Options object doesn't appear to be used anywhere after passed to HTTP.call, so JSON-stringifying it seems fine (and we can always parse it if we need the raw data again elsewhere).
