### PR TITLE
Adding Proxy for Client Side Intercepts

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -43,6 +43,17 @@
           }
         }
       }
+    },
+    "http-proxy": {
+      "version": "1.11.1",
+      "dependencies": {
+        "eventemitter3": {
+          "version": "1.1.1"
+        },
+        "requires-port": {
+          "version": "0.0.1"
+        }
+      }
     }
   }
 }

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -43,17 +43,6 @@
           }
         }
       }
-    },
-    "http-proxy": {
-      "version": "1.11.1",
-      "dependencies": {
-        "eventemitter3": {
-          "version": "1.1.1"
-        },
-        "requires-port": {
-          "version": "0.0.1"
-        }
-      }
     }
   }
 }

--- a/log.js
+++ b/log.js
@@ -1,0 +1,1 @@
+log = loglevel.createPackageLogger('xolvio:http-interceptor', 'info');

--- a/package.js
+++ b/package.js
@@ -6,8 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  'body-parser': '1.10.1',
-  'http-proxy': '1.11.1'
+  'body-parser': '1.10.1'
 });
 
 Package.on_use(function (api) {

--- a/package.js
+++ b/package.js
@@ -20,6 +20,8 @@ Package.on_use(function (api) {
 
   api.use(['iron:router@1.0.9'], ['server']);
 
+  api.add_files('log.js');
+
   api.add_files('client.css', 'client');
   api.add_files('client.html', 'client');
 

--- a/package.js
+++ b/package.js
@@ -6,7 +6,8 @@ Package.describe({
 });
 
 Npm.depends({
-  'body-parser': '1.10.1'
+  'body-parser': '1.10.1',
+  'http-proxy': '1.11.1'
 });
 
 Package.on_use(function (api) {
@@ -25,6 +26,7 @@ Package.on_use(function (api) {
 
   api.add_files('collection.js', ['server', 'client']);
   api.add_files('server.js', 'server');
+  api.add_files('proxy.js', 'server');
   api.add_files('client.js', 'client');
 
   api.export('HttpInterceptor', ['server', 'client']);

--- a/proxy.js
+++ b/proxy.js
@@ -1,10 +1,37 @@
+/**
+ * Crude proxy to allow for some client side fu
+ * Intercepting client side calls to hosts registered with HttpInterceptor.registerInterceptor()
+ */
 var http = Npm.require('http');
+var url = Npm.require('url');
+
+HttpInterceptor.registerInterceptor('http://res.cloudinary.com', Meteor.absoluteUrl('fake.res.cloudinary.com'));
+Meteor._debug(HttpInterceptor.getInterceptors());
 
 http.createServer(function(request, response) {
-    Meteor._debug('HELLO from da proxy.');
-    var proxy = http.createClient(80, request.headers['host']);
-    Meteor._debug('Just created a client for: ' + request.headers['host']);
-    var proxy_request = proxy.request(request.method, request.url, request.headers);
+    var interceptors = HttpInterceptor.getInterceptors();
+    var oldUrl = request.url;
+    var newUrl = oldUrl;
+    var oldHost = request.headers['host'];
+    var host = oldHost;
+
+    _.each(interceptors, function (newHost, originalHost) {
+        if (newUrl.indexOf(originalHost) > -1) {
+            Meteor._debug(newUrl, originalHost);
+            newUrl = newUrl.replace(originalHost, newHost);
+            Meteor._debug('REROUTING', oldUrl, '->', newUrl);
+            host = url.parse(newHost).hostname;
+            Meteor._debug(host);
+        }
+    });
+
+
+
+    var proxy = http.createClient(80, host);
+    Meteor._debug('Just created a client for: ' + host);
+    var proxy_request = proxy.request(request.method, newUrl, request.headers);
+    Meteor._debug('Using method: ' + request.method);
+    Meteor._debug('Accessing URL: ' + newUrl);
     proxy_request.addListener('response', function (proxy_response) {
         proxy_response.addListener('data', function(chunk) {
             response.write(chunk, 'binary');

--- a/proxy.js
+++ b/proxy.js
@@ -33,6 +33,7 @@ HTTP.createServer(function(request, response) {
             url = url.replace(originalHost, newHost);
             log.debug('CAPTURING', oldUrl, '->', url);
             host = URL.parse(newHost).hostname;
+            port = _port;
         }
     });
 

--- a/proxy.js
+++ b/proxy.js
@@ -5,8 +5,13 @@
 var http = Npm.require('http');
 var URL = Npm.require('url');
 
+var _PORT_OFFSET = 42;
+var _port = Number(URL.parse(process.env.ROOT_URL).port) + _PORT_OFFSET;
+
 HttpInterceptor.registerInterceptor('http://res.cloudinary.com', Meteor.absoluteUrl('fake.res.cloudinary.com'));
-Meteor._debug(HttpInterceptor.getInterceptors());
+
+Meteor._debug('Starting a proxy server to intercept client side calls on port: ' + _port);
+
 
 http.createServer(function(request, response) {
     var interceptors = HttpInterceptor.getInterceptors();
@@ -45,4 +50,4 @@ http.createServer(function(request, response) {
     request.addListener('end', function() {
         proxy_request.end();
     });
-}).listen(8080);
+}).listen(_port);

--- a/proxy.js
+++ b/proxy.js
@@ -1,0 +1,23 @@
+var http = Npm.require('http');
+
+http.createServer(function(request, response) {
+    Meteor._debug('HELLO from da proxy.');
+    var proxy = http.createClient(80, request.headers['host']);
+    Meteor._debug('Just created a client for: ' + request.headers['host']);
+    var proxy_request = proxy.request(request.method, request.url, request.headers);
+    proxy_request.addListener('response', function (proxy_response) {
+        proxy_response.addListener('data', function(chunk) {
+            response.write(chunk, 'binary');
+        });
+        proxy_response.addListener('end', function() {
+            response.end();
+        });
+        response.writeHead(proxy_response.statusCode, proxy_response.headers);
+    });
+    request.addListener('data', function(chunk) {
+        proxy_request.write(chunk, 'binary');
+    });
+    request.addListener('end', function() {
+        proxy_request.end();
+    });
+}).listen(8080);

--- a/proxy.js
+++ b/proxy.js
@@ -3,7 +3,7 @@
  * Intercepting client side calls to hosts registered with HttpInterceptor.registerInterceptor()
  */
 var http = Npm.require('http');
-var url = Npm.require('url');
+var URL = Npm.require('url');
 
 HttpInterceptor.registerInterceptor('http://res.cloudinary.com', Meteor.absoluteUrl('fake.res.cloudinary.com'));
 Meteor._debug(HttpInterceptor.getInterceptors());
@@ -11,28 +11,26 @@ Meteor._debug(HttpInterceptor.getInterceptors());
 http.createServer(function(request, response) {
     var interceptors = HttpInterceptor.getInterceptors();
     var oldUrl = request.url;
-    var newUrl = oldUrl;
-    var oldHost = request.headers['host'];
-    var host = oldHost;
+    var url = oldUrl;
+    var host = request.headers['host'];
+    var proxy, proxy_request;
 
-    _.each(interceptors, function (newHost, originalHost) {
-        if (newUrl.indexOf(originalHost) > -1) {
-            Meteor._debug(newUrl, originalHost);
-            newUrl = newUrl.replace(originalHost, newHost);
-            Meteor._debug('REROUTING', oldUrl, '->', newUrl);
-            host = url.parse(newHost).hostname;
+    _.each(interceptors, function(newHost, originalHost) {
+        if (url.indexOf(originalHost) > -1) {
+            Meteor._debug(url, originalHost);
+            url = url.replace(originalHost, newHost);
+            Meteor._debug('CAPTURING', oldUrl, '->', url);
+            host = URL.parse(newHost).hostname;
             Meteor._debug(host);
         }
     });
 
-
-
-    var proxy = http.createClient(80, host);
+    proxy = http.createClient(80, host);
     Meteor._debug('Just created a client for: ' + host);
-    var proxy_request = proxy.request(request.method, newUrl, request.headers);
+    proxy_request = proxy.request(request.method, url, request.headers);
     Meteor._debug('Using method: ' + request.method);
-    Meteor._debug('Accessing URL: ' + newUrl);
-    proxy_request.addListener('response', function (proxy_response) {
+    Meteor._debug('Accessing URL: ' + url);
+    proxy_request.addListener('response', function(proxy_response) {
         proxy_response.addListener('data', function(chunk) {
             response.write(chunk, 'binary');
         });

--- a/server.js
+++ b/server.js
@@ -6,8 +6,7 @@ var Fiber                 = Npm.require('fibers'),
     _originalCallFunction = {},
     _ignores              = [],
     _routeNameCache       = {},
-    _recording            = false,
-    log                   = loglevel.createPackageLogger('http-interceptor', defaultLevel = 'info');
+    _recording            = false;
 
 
 _init();
@@ -63,7 +62,7 @@ HttpInterceptor = HttpInterceptor || {};
 _.extend(HttpInterceptor, {
 
   registerInterceptor: function (originalHost, newHost) {
-    log.debug('Intercepting all calls to', originalHost, 'and redirecting to', newHost);
+    log.info('Intercepting all calls to', originalHost, 'and redirecting to', newHost);
     _interceptors[originalHost] = newHost;
   },
 

--- a/server.js
+++ b/server.js
@@ -67,6 +67,10 @@ _.extend(HttpInterceptor, {
     _interceptors[originalHost] = newHost;
   },
 
+  getInterceptors: function() {
+    return _interceptors;
+  },
+
   ignore: function (urls) {
     if (urls instanceof Array) {
       _ignores = _ignores.concat(urls);


### PR DESCRIPTION
Neat! I set up a proxy and it seems to be running fine with a couple of limitations (lurking below).
# Questions
1. Telling Selenium/Webdriver to use the proxy should probably happen in `chimp`, right? How do we best wire the two together?
2. Proxy supports HTTP only so far. Writing an actual HTTPS proxy with certificates and cross-browser settings seems a bit daunting for the task. I thought of just replacing any references to (intercepted) `https://` calls directly in the DOM. Have a better idea or more experience setting up a proxy? :)
3. Should we spawn the proxy process with `sanjo:long-running-child-process`? It seems to work fine without, but maybe I'm missing some edge cases or other benefits.
4. Should we have the proxy run on the velocity mirror only?
# TODO
- [ ] Handle HTTPS
- [ ] Support WebSockets
- [ ] Wire up with Chimp?
- [ ] Should it run on mirror only?
- [ ] Spawn process with sanjo:long-running-child-process?
